### PR TITLE
Cope with escaped single quotes in template cache markup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-cache-bust",
   "description": "Bust static assets from the cache using content hashing",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "author": "Ben Holland <hi@benholland.me>",
   "repository": {
     "type": "git",

--- a/tasks/cachebust.js
+++ b/tasks/cachebust.js
@@ -91,7 +91,8 @@ module.exports = function(grunt) {
         // \s{file}\s (other entries of img srcset)
         // files may contain a querystring, so all with ? as closing too
         var replaceEnclosedBy = [
-            ['\\"', '\\"'], // copes with templateCache js files where markup has been escaped in JSON strings
+            ['\\"', '\\"'], // cope with escaped double quotes in templateCache js files where markup has been escaped in string literals
+            ["\\'", "\\'"], // cope with escaped single quotes in templateCache js files where markup has been escaped in string literals
             ['"', '"'],
             ["'", "'"],
             ['(', ')'],


### PR DESCRIPTION
This will fix our images missing in Sandman US